### PR TITLE
chore: adiciona CLAUDE.md e melhora template de PR

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -26,11 +26,24 @@
 - [ ] Testes passam (`npm run test`)
 - [ ] Testado manualmente no navegador
 
+## Qualidade do Código
+
+### Soluções que precisam justificativa:
+- [ ] Não usei `@ts-nocheck` ou `@ts-ignore`
+- [ ] Não usei `any` sem necessidade
+- [ ] Não desabilitei regras de lint em massa
+- [ ] A solução resolve o problema (não apenas esconde)
+
+<!-- Se marcou algum item como NÃO, justifique abaixo -->
+**Justificativa (se aplicável):**
+
+
 ## Checklist
 
 - [ ] Meu código segue o padrão de estilo do projeto
 - [ ] Realizei self-review do meu código
 - [ ] Testei em diferentes tamanhos de tela
+- [ ] Li o CLAUDE.md e segui as diretrizes
 
 ## Issues relacionadas
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,14 +66,6 @@ Antes de abrir PR, verificar:
 - [ ] Nao usei `any` sem necessidade
 - [ ] Nao desabilitei regras de lint sem motivo
 
-## Dividas Tecnicas Conhecidas
-
-### @ts-nocheck em arquivos legados
-- **Status:** ~40 arquivos com @ts-nocheck
-- **Origem:** PR #33 (correcao de lint para CI passar)
-- **Acao:** Remover gradualmente e corrigir tipos reais
-- **Issue:** TODO - criar issue para tracking
-
 ## Contatos
 
 - **CTO:** MatheusBlanco (GitHub)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,80 @@
+# PostNow-UI - Guia para Claude
+
+## Sobre o Projeto
+- **Stack:** React 18 + TypeScript + Vite
+- **Estilo:** Tailwind CSS + shadcn/ui
+- **Testes:** Vitest + Testing Library
+- **Lint:** ESLint com regras strict
+- **Estado:** TanStack Query + React Context
+
+## Regras de Qualidade TypeScript
+
+### NUNCA fazer sem questionar o usuario:
+
+1. **`@ts-nocheck` ou `@ts-ignore`**
+   - Pergunta obrigatoria: "Precisa mesmo suprimir os erros de tipo? Posso corrigir os tipos reais."
+   - Se o usuario insistir: documentar como divida tecnica
+
+2. **`any` em mais de 2 lugares**
+   - Sugerir tipos especificos antes de usar `any`
+   - Se necessario: usar `unknown` com type guards
+
+3. **`eslint-disable` em massa**
+   - Corrigir os erros reais, nao suprimir
+   - Se for regra problematica: ajustar config, nao desabilitar inline
+
+4. **Catch vazio ou generico**
+   - Sempre tratar ou logar erros
+   - Nunca `catch (e) {}` ou `catch (_) {}`
+
+### Regra de Ouro
+
+> Antes de suprimir um erro, perguntar: "Isso RESOLVE o problema ou apenas ESCONDE?"
+
+- Se esconde: corrigir o problema real
+- Se nao tem como corrigir agora: criar issue documentando a divida tecnica
+
+## Padroes de Codigo
+
+### Componentes React
+- Function components com TypeScript
+- Props tipadas com interface (nao type)
+- Hooks customizados em `/hooks`
+
+### Imports
+- Usar alias `@/` para imports absolutos
+- Agrupar: externos, internos, tipos, estilos
+
+### Testes
+- Cobertura minima esperada: hooks e componentes criticos
+- Mock de APIs externas obrigatorio
+- Usar `data-testid` para queries de teste
+
+### Commits
+- Seguir Conventional Commits (feat, fix, docs, etc.)
+- Mensagens em ingles ou portugues (consistente por PR)
+- Co-author do Claude quando aplicavel
+
+## Checklist Pre-PR
+
+Antes de abrir PR, verificar:
+
+- [ ] `npm run lint` passa sem erros
+- [ ] `npm run test` passa (todos os testes)
+- [ ] `npm run build` compila sem erros
+- [ ] Nao usei `@ts-nocheck` sem justificativa
+- [ ] Nao usei `any` sem necessidade
+- [ ] Nao desabilitei regras de lint sem motivo
+
+## Dividas Tecnicas Conhecidas
+
+### @ts-nocheck em arquivos legados
+- **Status:** ~40 arquivos com @ts-nocheck
+- **Origem:** PR #33 (correcao de lint para CI passar)
+- **Acao:** Remover gradualmente e corrigir tipos reais
+- **Issue:** TODO - criar issue para tracking
+
+## Contatos
+
+- **CTO:** MatheusBlanco (GitHub)
+- **Repositorio:** PostNow-AI/PostNow-UI


### PR DESCRIPTION
## Tipo de mudança
- [x] `chore`: Manutenção

## Descrição

Melhorias de processo após feedback do CTO na PR #33 sobre uso excessivo de `@ts-nocheck`.

### Mudanças

#### 1. CLAUDE.md (novo arquivo)

Guia para o Claude seguir ao trabalhar no projeto:

- **Regra de Ouro:** "Isso RESOLVE o problema ou apenas ESCONDE?"
- **Alertas obrigatórios:** `@ts-nocheck`, `@ts-ignore`, `any`, `eslint-disable`, `catch` vazio
- **Checklist pré-PR**
- **Padrões de código** (componentes, imports, testes, commits)

#### 2. Template de PR atualizado

Nova seção "Qualidade do Código" com:

```markdown
### Soluções que precisam justificativa:
- [ ] Não usei `@ts-nocheck` ou `@ts-ignore`
- [ ] Não usei `any` sem necessidade
- [ ] Não desabilitei regras de lint em massa
- [ ] A solução resolve o problema (não apenas esconde)
```

### Revisão (commit aab5059)

- Removida seção "Dívidas Técnicas Conhecidas" que mencionava ~40 arquivos com `@ts-nocheck` — o CTO já removeu todos no merge da PR #33. Manter essa info seria incorreto.

### Objetivo

Evitar que soluções que mascaram problemas passem despercebidas em futuras PRs.

## Como foi testado?

- [x] `npm run lint` passa
- [x] `npm run build` compila
- [x] Testes passam (`npm run test`)
- [x] Arquivos são válidos (markdown)

## Qualidade do Código

### Soluções que precisam justificativa:
- [x] Não usei `@ts-nocheck` ou `@ts-ignore`
- [x] Não usei `any` sem necessidade
- [x] Não desabilitei regras de lint em massa
- [x] A solução resolve o problema (não apenas esconde)

## Checklist

- [x] Meu código segue o padrão de estilo do projeto
- [x] Realizei self-review do meu código
- [x] Li o CLAUDE.md e segui as diretrizes

## Issues relacionadas

Feedback da PR #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)