### PR TITLE
feat: add /create page for email opportunity links (v2)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,6 +37,7 @@ import RegisterPage from "./pages/RegisterPage";
 import { SubscriptionPage } from "./pages/SubscriptionPage";
 import OnboardingPage from "./pages/OnboardingPage";
 import PrivacyPolicyPage from "./pages/PrivacyPolicyPage";
+import { CreateFromOpportunityPage } from "./pages/CreateFromOpportunityPage";
 
 const App = () => {
   if (import.meta.env.MODE === "production") {
@@ -185,6 +186,16 @@ const App = () => {
                   </ProtectedRoute>
                 }
               /> */}
+
+              {/* Create from Opportunity - Full page (accessed via email link) */}
+              <Route
+                path="/create"
+                element={
+                  <ProtectedRoute>
+                    <CreateFromOpportunityPage />
+                  </ProtectedRoute>
+                }
+              />
             </Routes>
             <Toaster />
           </AuthProvider>

--- a/src/features/CreateFromOpportunity/__tests__/CreateFromOpportunity.test.tsx
+++ b/src/features/CreateFromOpportunity/__tests__/CreateFromOpportunity.test.tsx
@@ -1,0 +1,133 @@
+import { render, screen, cleanup } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { CreateFromOpportunity } from "../index";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+// Mock react-router-dom
+const mockNavigate = vi.fn();
+vi.mock("react-router-dom", () => ({
+  useNavigate: () => mockNavigate,
+  useSearchParams: () => [
+    new URLSearchParams(
+      "topic=IA%20substituindo%20empregos&category=polemica&score=95"
+    ),
+  ],
+}));
+
+// Mock lucide-react
+vi.mock("lucide-react", () => ({
+  ArrowLeft: () => <span data-testid="icon-arrow-left">back</span>,
+  ArrowRight: () => <span data-testid="icon-arrow-right">next</span>,
+  Check: () => <span data-testid="icon-check">check</span>,
+  Sparkles: () => <span data-testid="icon-sparkles">sparkles</span>,
+  Loader2: () => <span data-testid="icon-loader">loading</span>,
+  CheckCircle2: () => <span data-testid="icon-check-circle">success</span>,
+  ExternalLink: () => <span data-testid="icon-external">external</span>,
+  Plus: () => <span data-testid="icon-plus">plus</span>,
+}));
+
+// Mock the service
+vi.mock("../services", () => ({
+  createFromOpportunityService: {
+    getVisualStyles: vi.fn().mockResolvedValue([
+      { id: 1, name: "Minimalista", description: "Design limpo" },
+      { id: 2, name: "Bold", description: "Cores fortes" },
+    ]),
+    generatePost: vi.fn().mockResolvedValue({ message: "Post gerado" }),
+  },
+}));
+
+// Mock sonner
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+};
+
+describe("CreateFromOpportunity", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe("Renderização inicial", () => {
+    it("deve renderizar o header com logo", async () => {
+      render(<CreateFromOpportunity />, { wrapper: createWrapper() });
+
+      // Deve ter a imagem do logo
+      const logos = screen.getAllByAltText("PostNow");
+      expect(logos.length).toBeGreaterThan(0);
+    });
+
+    it("deve renderizar o step indicator", async () => {
+      render(<CreateFromOpportunity />, { wrapper: createWrapper() });
+
+      // Deve mostrar os 3 passos (usando getAllByText pois pode haver múltiplos elementos)
+      const stepElements = screen.getAllByText("1");
+      expect(stepElements.length).toBeGreaterThan(0);
+    });
+
+    it("deve começar no passo 1 (Topic)", async () => {
+      render(<CreateFromOpportunity />, { wrapper: createWrapper() });
+
+      // Deve mostrar elementos do StepTopic
+      const buttons = screen.getAllByText("Continuar");
+      expect(buttons.length).toBeGreaterThan(0);
+    });
+
+    it("deve mostrar o tópico da URL", async () => {
+      render(<CreateFromOpportunity />, { wrapper: createWrapper() });
+
+      const topics = screen.getAllByText("IA substituindo empregos");
+      expect(topics.length).toBeGreaterThan(0);
+    });
+
+    it("deve mostrar o score da URL", async () => {
+      render(<CreateFromOpportunity />, { wrapper: createWrapper() });
+
+      const scores = screen.getAllByText("95/100");
+      expect(scores.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("Header", () => {
+    it("deve mostrar botão Voltar no passo 1", async () => {
+      render(<CreateFromOpportunity />, { wrapper: createWrapper() });
+
+      const buttons = screen.getAllByText("Voltar");
+      expect(buttons.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("Acessibilidade", () => {
+    it("deve ter estrutura semântica correta", async () => {
+      const { container } = render(<CreateFromOpportunity />, {
+        wrapper: createWrapper(),
+      });
+
+      // Deve ter header
+      expect(container.querySelector("header")).toBeInTheDocument();
+
+      // Deve ter main
+      expect(container.querySelector("main")).toBeInTheDocument();
+    });
+  });
+});

--- a/src/features/CreateFromOpportunity/components/MobileStepIndicator.tsx
+++ b/src/features/CreateFromOpportunity/components/MobileStepIndicator.tsx
@@ -1,0 +1,50 @@
+import { Check } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface MobileStepIndicatorProps {
+  currentStep: number;
+  totalSteps: number;
+}
+
+export const MobileStepIndicator = ({
+  currentStep,
+  totalSteps,
+}: MobileStepIndicatorProps) => {
+  const steps = Array.from({ length: totalSteps }, (_, i) => i + 1);
+
+  return (
+    <div className="flex items-center justify-center gap-2 py-4">
+      {steps.map((step) => {
+        const isCompleted = step < currentStep;
+        const isCurrent = step === currentStep;
+
+        return (
+          <div key={step} className="flex items-center">
+            <div
+              className={cn(
+                "flex items-center justify-center w-8 h-8 rounded-full text-sm font-medium transition-all",
+                isCompleted && "bg-primary text-primary-foreground",
+                isCurrent && "bg-primary text-primary-foreground ring-2 ring-primary ring-offset-2",
+                !isCompleted && !isCurrent && "bg-muted text-muted-foreground"
+              )}
+            >
+              {isCompleted ? (
+                <Check className="w-4 h-4" />
+              ) : (
+                step
+              )}
+            </div>
+            {step < totalSteps && (
+              <div
+                className={cn(
+                  "w-8 h-0.5 mx-1",
+                  step < currentStep ? "bg-primary" : "bg-muted"
+                )}
+              />
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+};

--- a/src/features/CreateFromOpportunity/components/StepGenerate.tsx
+++ b/src/features/CreateFromOpportunity/components/StepGenerate.tsx
@@ -1,0 +1,50 @@
+import { Loader2, Sparkles } from "lucide-react";
+import { Progress } from "@/components/ui/progress";
+import type { VisualStyle } from "../types";
+
+interface StepGenerateProps {
+  isGenerating: boolean;
+  selectedStyle: VisualStyle | undefined;
+  businessName?: string;
+}
+
+export const StepGenerate = ({
+  isGenerating,
+  selectedStyle,
+}: StepGenerateProps) => {
+  return (
+    <div className="flex flex-col items-center justify-center min-h-[60vh] px-4">
+      {/* Spinner */}
+      <div className="relative mb-8">
+        <div className="w-24 h-24 rounded-full bg-primary/10 flex items-center justify-center">
+          {isGenerating ? (
+            <Loader2 className="w-12 h-12 text-primary animate-spin" />
+          ) : (
+            <Sparkles className="w-12 h-12 text-primary" />
+          )}
+        </div>
+      </div>
+
+      {/* Message */}
+      <h2 className="text-xl font-semibold text-foreground mb-2 text-center">
+        {isGenerating ? "Criando seu post..." : "Preparando..."}
+      </h2>
+
+      {selectedStyle && (
+        <p className="text-muted-foreground text-center mb-8">
+          Usando estilo <span className="font-medium">{selectedStyle.name}</span>
+        </p>
+      )}
+
+      {/* Progress Bar */}
+      {isGenerating && (
+        <div className="w-full max-w-xs space-y-2">
+          <Progress value={undefined} className="h-2 animate-pulse" />
+          <p className="text-sm text-muted-foreground text-center">
+            Gerando conteudo...
+          </p>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/features/CreateFromOpportunity/components/StepGenerate.tsx
+++ b/src/features/CreateFromOpportunity/components/StepGenerate.tsx
@@ -5,7 +5,6 @@ import type { VisualStyle } from "../types";
 interface StepGenerateProps {
   isGenerating: boolean;
   selectedStyle: VisualStyle | undefined;
-  businessName?: string;
 }
 
 export const StepGenerate = ({
@@ -41,7 +40,7 @@ export const StepGenerate = ({
         <div className="w-full max-w-xs space-y-2">
           <Progress value={undefined} className="h-2 animate-pulse" />
           <p className="text-sm text-muted-foreground text-center">
-            Gerando conteudo...
+            Gerando conteúdo...
           </p>
         </div>
       )}

--- a/src/features/CreateFromOpportunity/components/StepStyle.tsx
+++ b/src/features/CreateFromOpportunity/components/StepStyle.tsx
@@ -1,0 +1,125 @@
+import { Sparkles, ArrowLeft, Check } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+import type { VisualStyle } from "../types";
+
+interface StepStyleProps {
+  visualStyles: VisualStyle[];
+  isLoading: boolean;
+  selectedStyleId: number | null;
+  onSelectStyle: (styleId: number) => void;
+  onBack: () => void;
+  onGenerate: () => void;
+}
+
+export const StepStyle = ({
+  visualStyles,
+  isLoading,
+  selectedStyleId,
+  onSelectStyle,
+  onBack,
+  onGenerate,
+}: StepStyleProps) => {
+  return (
+    <div className="flex flex-col h-full">
+      {/* Header */}
+      <div className="px-4 pb-4">
+        <h2 className="text-lg font-semibold text-foreground mb-1">
+          Escolha o estilo visual
+        </h2>
+        <p className="text-sm text-muted-foreground">
+          Selecione o estilo que melhor representa sua marca
+        </p>
+      </div>
+
+      {/* Grid - scrollable */}
+      <div className="flex-1 overflow-auto px-4 pb-32">
+        {isLoading ? (
+          <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+            {Array.from({ length: 8 }).map((_, i) => (
+              <Skeleton key={i} className="aspect-square rounded-lg" />
+            ))}
+          </div>
+        ) : (
+          <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+            {visualStyles.map((style) => {
+              const isSelected = selectedStyleId === style.id;
+
+              return (
+                <Card
+                  key={style.id}
+                  className={cn(
+                    "cursor-pointer transition-all overflow-hidden",
+                    "hover:ring-2 hover:ring-primary/50",
+                    isSelected && "ring-2 ring-primary"
+                  )}
+                  onClick={() => onSelectStyle(style.id)}
+                >
+                  <CardContent className="p-0">
+                    {/* Preview Image */}
+                    <div className="aspect-square relative bg-muted">
+                      {style.preview_image_url ? (
+                        <img
+                          src={style.preview_image_url}
+                          alt={style.name}
+                          className="w-full h-full object-cover"
+                        />
+                      ) : (
+                        <div className="w-full h-full flex items-center justify-center bg-gradient-to-br from-primary/20 to-primary/5">
+                          <span className="text-4xl">
+                            {style.name.charAt(0).toUpperCase()}
+                          </span>
+                        </div>
+                      )}
+
+                      {/* Selected Indicator */}
+                      {isSelected && (
+                        <div className="absolute inset-0 bg-primary/20 flex items-center justify-center">
+                          <div className="w-10 h-10 rounded-full bg-primary flex items-center justify-center">
+                            <Check className="w-6 h-6 text-primary-foreground" />
+                          </div>
+                        </div>
+                      )}
+                    </div>
+
+                    {/* Style Name */}
+                    <div className="p-3">
+                      <h3 className="text-sm font-medium text-foreground truncate">
+                        {style.name}
+                      </h3>
+                    </div>
+                  </CardContent>
+                </Card>
+              );
+            })}
+          </div>
+        )}
+      </div>
+
+      {/* Fixed Footer */}
+      <div className="fixed bottom-0 left-0 right-0 p-4 bg-background border-t">
+        <div className="max-w-lg mx-auto flex gap-3">
+          <Button
+            variant="outline"
+            onClick={onBack}
+            className="h-12"
+          >
+            <ArrowLeft className="w-4 h-4 mr-2" />
+            Voltar
+          </Button>
+          <Button
+            onClick={onGenerate}
+            disabled={!selectedStyleId}
+            className="flex-1 h-12 text-base font-semibold"
+            size="lg"
+          >
+            <Sparkles className="w-5 h-5 mr-2" />
+            Gerar Post
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/features/CreateFromOpportunity/components/StepSuccess.tsx
+++ b/src/features/CreateFromOpportunity/components/StepSuccess.tsx
@@ -1,0 +1,111 @@
+import { CheckCircle2, ExternalLink, Plus, Download, Copy } from "lucide-react";
+import { useNavigate } from "react-router-dom";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+
+interface StepSuccessProps {
+  onCreateAnother: () => void;
+  generatedContent: string | null;
+  generatedImageUrl: string | null;
+}
+
+export const StepSuccess = ({
+  onCreateAnother,
+  generatedContent,
+  generatedImageUrl,
+}: StepSuccessProps) => {
+  const navigate = useNavigate();
+
+  const handleCopyContent = () => {
+    if (generatedContent) {
+      navigator.clipboard.writeText(generatedContent);
+      toast.success("Conteudo copiado!");
+    }
+  };
+
+  const handleDownloadImage = () => {
+    if (generatedImageUrl) {
+      window.open(generatedImageUrl, "_blank");
+    }
+  };
+
+  return (
+    <div className="flex flex-col items-center px-4 pb-8">
+      {/* Success Header */}
+      <div className="flex items-center gap-3 mb-6">
+        <div className="w-10 h-10 rounded-full bg-green-100 dark:bg-green-900/30 flex items-center justify-center">
+          <CheckCircle2 className="w-6 h-6 text-green-600 dark:text-green-400" />
+        </div>
+        <h2 className="text-xl font-bold text-foreground">
+          Post gerado com sucesso!
+        </h2>
+      </div>
+
+      {/* Generated Image */}
+      {generatedImageUrl && (
+        <div className="w-full max-w-sm mb-4">
+          <div className="relative aspect-[4/5] rounded-lg overflow-hidden bg-muted">
+            <img
+              src={generatedImageUrl}
+              alt="Post gerado"
+              className="w-full h-full object-cover"
+            />
+            <Button
+              size="sm"
+              variant="secondary"
+              className="absolute bottom-2 right-2"
+              onClick={handleDownloadImage}
+            >
+              <Download className="w-4 h-4 mr-1" />
+              Baixar
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {/* Generated Content */}
+      {generatedContent && (
+        <Card className="w-full max-w-sm mb-6">
+          <CardContent className="pt-4">
+            <div className="flex items-center justify-between mb-2">
+              <span className="text-sm font-medium text-muted-foreground">Legenda</span>
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={handleCopyContent}
+              >
+                <Copy className="w-4 h-4 mr-1" />
+                Copiar
+              </Button>
+            </div>
+            <p className="text-sm text-foreground whitespace-pre-wrap leading-relaxed max-h-48 overflow-y-auto">
+              {generatedContent}
+            </p>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Actions */}
+      <div className="w-full max-w-sm space-y-3">
+        <Button
+          onClick={() => navigate("/ideabank")}
+          className="w-full h-12 text-base font-semibold"
+          size="lg"
+        >
+          Ver na Biblioteca
+          <ExternalLink className="w-4 h-4 ml-2" />
+        </Button>
+
+        <Button
+          variant="outline"
+          onClick={onCreateAnother}
+          className="w-full h-12"
+        >
+          <Plus className="w-4 h-4 mr-2" />
+          Criar Outro Post
+        </Button>
+      </div>
+    </div>
+  );
+};

--- a/src/features/CreateFromOpportunity/components/StepSuccess.tsx
+++ b/src/features/CreateFromOpportunity/components/StepSuccess.tsx
@@ -17,16 +17,25 @@ export const StepSuccess = ({
 }: StepSuccessProps) => {
   const navigate = useNavigate();
 
-  const handleCopyContent = () => {
+  const handleCopyContent = async () => {
     if (generatedContent) {
-      navigator.clipboard.writeText(generatedContent);
-      toast.success("Conteudo copiado!");
+      try {
+        await navigator.clipboard.writeText(generatedContent);
+        toast.success("Conteúdo copiado!");
+      } catch {
+        toast.error("Não foi possível copiar o conteúdo");
+      }
     }
   };
 
   const handleDownloadImage = () => {
     if (generatedImageUrl) {
-      window.open(generatedImageUrl, "_blank");
+      const link = document.createElement("a");
+      link.href = generatedImageUrl;
+      link.download = "post.png";
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
     }
   };
 

--- a/src/features/CreateFromOpportunity/components/StepTopic.tsx
+++ b/src/features/CreateFromOpportunity/components/StepTopic.tsx
@@ -1,0 +1,136 @@
+import { ArrowRight, ChevronLeft, ChevronRight } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Textarea } from "@/components/ui/textarea";
+import { Badge } from "@/components/ui/badge";
+import { CATEGORY_LABELS, type CategoryKey } from "../types";
+
+interface StepTopicProps {
+  topic: string;
+  category: CategoryKey;
+  score: number;
+  furtherDetails: string;
+  onFurtherDetailsChange: (details: string) => void;
+  onNext: () => void;
+  // Navigation props
+  currentIndex?: number;
+  totalOpportunities?: number;
+  canNavigatePrev?: boolean;
+  canNavigateNext?: boolean;
+  onPrevOpportunity?: () => void;
+  onNextOpportunity?: () => void;
+}
+
+export const StepTopic = ({
+  topic,
+  category,
+  score,
+  furtherDetails,
+  onFurtherDetailsChange,
+  onNext,
+  currentIndex = -1,
+  totalOpportunities = 0,
+  canNavigatePrev = false,
+  canNavigateNext = false,
+  onPrevOpportunity,
+  onNextOpportunity,
+}: StepTopicProps) => {
+  const categoryInfo = CATEGORY_LABELS[category] || CATEGORY_LABELS.outros;
+  const showNavigation = totalOpportunities > 1;
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Content area - scrollable */}
+      <div className="flex-1 overflow-auto px-4 pb-24">
+        {/* Topic Card */}
+        <Card className="mb-6">
+          <CardContent className="pt-6">
+            {/* Category Badge */}
+            <Badge
+              variant="secondary"
+              className="mb-4 text-sm"
+            >
+              {categoryInfo.emoji} {categoryInfo.label}
+            </Badge>
+
+            {/* Topic Title */}
+            <h2 className="text-xl md:text-2xl font-bold text-foreground mb-4 leading-tight">
+              {topic || "Tema da Oportunidade"}
+            </h2>
+
+            {/* Score Badge */}
+            <div className="flex items-center gap-2">
+              <span className="text-sm text-muted-foreground">Score:</span>
+              <Badge
+                variant="default"
+                className="bg-primary text-primary-foreground"
+              >
+                {score}/100
+              </Badge>
+            </div>
+
+            {/* Opportunity Navigation */}
+            {showNavigation && (
+              <div className="flex items-center justify-between mt-4 pt-4 border-t">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={onPrevOpportunity}
+                  disabled={!canNavigatePrev}
+                  className="gap-1"
+                >
+                  <ChevronLeft className="w-4 h-4" />
+                  Anterior
+                </Button>
+                <span className="text-sm text-muted-foreground">
+                  {currentIndex + 1} de {totalOpportunities}
+                </span>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={onNextOpportunity}
+                  disabled={!canNavigateNext}
+                  className="gap-1"
+                >
+                  Próximo
+                  <ChevronRight className="w-4 h-4" />
+                </Button>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* Additional Details */}
+        <div className="space-y-3">
+          <label className="text-sm font-medium text-foreground">
+            Detalhes adicionais (opcional)
+          </label>
+          <Textarea
+            placeholder="Ex: Foque em dados do mercado brasileiro, mencione cases de sucesso, use tom mais informal..."
+            value={furtherDetails}
+            onChange={(e) => onFurtherDetailsChange(e.target.value)}
+            rows={4}
+            className="resize-none"
+          />
+          <p className="text-xs text-muted-foreground">
+            Adicione instruções específicas para personalizar ainda mais o conteúdo gerado.
+          </p>
+        </div>
+      </div>
+
+      {/* Fixed Footer */}
+      <div className="fixed bottom-0 left-0 right-0 p-4 bg-background border-t">
+        <div className="max-w-lg mx-auto">
+          <Button
+            onClick={onNext}
+            className="w-full h-12 text-base font-semibold"
+            size="lg"
+          >
+            Continuar
+            <ArrowRight className="w-5 h-5 ml-2" />
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/features/CreateFromOpportunity/components/__tests__/MobileStepIndicator.test.tsx
+++ b/src/features/CreateFromOpportunity/components/__tests__/MobileStepIndicator.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen, cleanup } from "@testing-library/react";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { MobileStepIndicator } from "../MobileStepIndicator";
+
+// Mock lucide-react
+vi.mock("lucide-react", () => ({
+  Check: () => <span data-testid="icon-check">check</span>,
+}));
+
+describe("MobileStepIndicator", () => {
+  afterEach(() => {
+    cleanup();
+  });
+  describe("Renderização básica", () => {
+    it("deve renderizar o número correto de passos", () => {
+      render(<MobileStepIndicator currentStep={1} totalSteps={3} />);
+
+      expect(screen.getByText("1")).toBeInTheDocument();
+      expect(screen.getByText("2")).toBeInTheDocument();
+      expect(screen.getByText("3")).toBeInTheDocument();
+    });
+
+    it("deve renderizar 4 passos quando totalSteps é 4", () => {
+      render(<MobileStepIndicator currentStep={1} totalSteps={4} />);
+
+      expect(screen.getByText("4")).toBeInTheDocument();
+    });
+  });
+
+  describe("Estado dos passos", () => {
+    it("deve mostrar check para passos completados", () => {
+      render(<MobileStepIndicator currentStep={3} totalSteps={3} />);
+
+      // Passos 1 e 2 devem ter check
+      const checks = screen.getAllByTestId("icon-check");
+      expect(checks).toHaveLength(2);
+    });
+
+    it("deve mostrar número para passo atual", () => {
+      render(<MobileStepIndicator currentStep={2} totalSteps={3} />);
+
+      // Passo 1 tem check, passo 2 mostra número
+      expect(screen.getByText("2")).toBeInTheDocument();
+    });
+
+    it("deve mostrar número para passos futuros", () => {
+      render(<MobileStepIndicator currentStep={1} totalSteps={3} />);
+
+      expect(screen.getByText("2")).toBeInTheDocument();
+      expect(screen.getByText("3")).toBeInTheDocument();
+    });
+  });
+
+  describe("Conectores entre passos", () => {
+    it("deve ter conectores entre passos", () => {
+      const { container } = render(
+        <MobileStepIndicator currentStep={1} totalSteps={3} />
+      );
+
+      // Deve ter 2 conectores (entre 1-2 e 2-3)
+      // Os conectores são divs com width 8 e height 0.5
+      const connectors = container.querySelectorAll(".h-0\\.5");
+      expect(connectors.length).toBe(2);
+    });
+  });
+
+  describe("Edge cases", () => {
+    it("deve funcionar com apenas 1 passo", () => {
+      render(<MobileStepIndicator currentStep={1} totalSteps={1} />);
+
+      expect(screen.getByText("1")).toBeInTheDocument();
+    });
+
+    it("deve funcionar no último passo", () => {
+      render(<MobileStepIndicator currentStep={3} totalSteps={3} />);
+
+      // Todos os passos anteriores devem ter check
+      const checks = screen.getAllByTestId("icon-check");
+      expect(checks).toHaveLength(2);
+
+      // Passo atual mostra número
+      expect(screen.getByText("3")).toBeInTheDocument();
+    });
+  });
+});

--- a/src/features/CreateFromOpportunity/components/__tests__/StepGenerate.test.tsx
+++ b/src/features/CreateFromOpportunity/components/__tests__/StepGenerate.test.tsx
@@ -95,7 +95,7 @@ describe("StepGenerate", () => {
         />
       );
 
-      expect(screen.getByText("Gerando conteudo...")).toBeInTheDocument();
+      expect(screen.getByText("Gerando conteúdo...")).toBeInTheDocument();
     });
 
     it("não deve mostrar progress bar quando não gerando", () => {
@@ -106,7 +106,7 @@ describe("StepGenerate", () => {
         />
       );
 
-      expect(screen.queryByText("Gerando conteudo...")).not.toBeInTheDocument();
+      expect(screen.queryByText("Gerando conteúdo...")).not.toBeInTheDocument();
     });
   });
 });

--- a/src/features/CreateFromOpportunity/components/__tests__/StepGenerate.test.tsx
+++ b/src/features/CreateFromOpportunity/components/__tests__/StepGenerate.test.tsx
@@ -1,0 +1,112 @@
+import { render, screen, cleanup } from "@testing-library/react";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { StepGenerate } from "../StepGenerate";
+
+// Mock lucide-react
+vi.mock("lucide-react", () => ({
+  Loader2: () => <span data-testid="icon-loader">loading</span>,
+  Sparkles: () => <span data-testid="icon-sparkles">sparkles</span>,
+}));
+
+describe("StepGenerate", () => {
+  afterEach(() => {
+    cleanup();
+  });
+  describe("Estado de geração", () => {
+    it("deve mostrar spinner quando gerando", () => {
+      render(
+        <StepGenerate
+          isGenerating={true}
+          selectedStyle={{ id: 1, name: "Minimalista", description: "Desc" }}
+        />
+      );
+
+      expect(screen.getByTestId("icon-loader")).toBeInTheDocument();
+    });
+
+    it("deve mostrar mensagem de criação quando gerando", () => {
+      render(
+        <StepGenerate
+          isGenerating={true}
+          selectedStyle={{ id: 1, name: "Minimalista", description: "Desc" }}
+        />
+      );
+
+      expect(screen.getByText("Criando seu post...")).toBeInTheDocument();
+    });
+
+    it("deve mostrar sparkles quando não gerando", () => {
+      render(
+        <StepGenerate
+          isGenerating={false}
+          selectedStyle={{ id: 1, name: "Minimalista", description: "Desc" }}
+        />
+      );
+
+      expect(screen.getByTestId("icon-sparkles")).toBeInTheDocument();
+    });
+
+    it("deve mostrar mensagem de preparação quando não gerando", () => {
+      render(
+        <StepGenerate
+          isGenerating={false}
+          selectedStyle={{ id: 1, name: "Minimalista", description: "Desc" }}
+        />
+      );
+
+      expect(screen.getByText("Preparando...")).toBeInTheDocument();
+    });
+  });
+
+  describe("Exibição do estilo selecionado", () => {
+    it("deve mostrar nome do estilo selecionado", () => {
+      render(
+        <StepGenerate
+          isGenerating={true}
+          selectedStyle={{ id: 1, name: "Bold Vibrante", description: "Desc" }}
+        />
+      );
+
+      expect(screen.getByText("Bold Vibrante")).toBeInTheDocument();
+    });
+
+    it("deve mostrar mensagem com estilo", () => {
+      render(
+        <StepGenerate
+          isGenerating={true}
+          selectedStyle={{
+            id: 1,
+            name: "Elegante Editorial",
+            description: "Desc",
+          }}
+        />
+      );
+
+      expect(screen.getByText(/Usando estilo/)).toBeInTheDocument();
+    });
+  });
+
+  describe("Progress bar", () => {
+    it("deve mostrar progress bar quando gerando", () => {
+      render(
+        <StepGenerate
+          isGenerating={true}
+          selectedStyle={{ id: 1, name: "Minimalista", description: "Desc" }}
+        />
+      );
+
+      expect(screen.getByText("Gerando conteudo...")).toBeInTheDocument();
+    });
+
+    it("não deve mostrar progress bar quando não gerando", () => {
+      render(
+        <StepGenerate
+          isGenerating={false}
+          selectedStyle={{ id: 1, name: "Minimalista", description: "Desc" }}
+        />
+      );
+
+      expect(screen.queryByText("Gerando conteudo...")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/features/CreateFromOpportunity/components/__tests__/StepStyle.test.tsx
+++ b/src/features/CreateFromOpportunity/components/__tests__/StepStyle.test.tsx
@@ -1,0 +1,168 @@
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { StepStyle } from "../StepStyle";
+import type { VisualStyle } from "../../types";
+
+// Mock lucide-react
+vi.mock("lucide-react", () => ({
+  Sparkles: () => <span data-testid="icon-sparkles">sparkles</span>,
+  ArrowLeft: () => <span data-testid="icon-arrow-left">arrow</span>,
+  Check: () => <span data-testid="icon-check">check</span>,
+}));
+
+describe("StepStyle", () => {
+  const mockStyles: VisualStyle[] = [
+    { id: 1, name: "Minimalista Moderno", description: "Design limpo" },
+    { id: 2, name: "Bold Vibrante", description: "Cores fortes" },
+    { id: 3, name: "Elegante Editorial", description: "Sofisticado" },
+  ];
+
+  const defaultProps = {
+    visualStyles: mockStyles,
+    isLoading: false,
+    selectedStyleId: null,
+    onSelectStyle: vi.fn(),
+    onBack: vi.fn(),
+    onGenerate: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe("Renderização", () => {
+    it("deve renderizar o título", () => {
+      render(<StepStyle {...defaultProps} />);
+
+      const titles = screen.getAllByText("Escolha o estilo visual");
+      expect(titles.length).toBeGreaterThan(0);
+    });
+
+    it("deve renderizar todos os estilos visuais", () => {
+      render(<StepStyle {...defaultProps} />);
+
+      const style1 = screen.getAllByText("Minimalista Moderno");
+      const style2 = screen.getAllByText("Bold Vibrante");
+      const style3 = screen.getAllByText("Elegante Editorial");
+      expect(style1.length).toBeGreaterThan(0);
+      expect(style2.length).toBeGreaterThan(0);
+      expect(style3.length).toBeGreaterThan(0);
+    });
+
+    it("deve renderizar o botão Voltar", () => {
+      render(<StepStyle {...defaultProps} />);
+
+      const buttons = screen.getAllByText("Voltar");
+      expect(buttons.length).toBeGreaterThan(0);
+    });
+
+    it("deve renderizar o botão Gerar Post", () => {
+      render(<StepStyle {...defaultProps} />);
+
+      const buttons = screen.getAllByText("Gerar Post");
+      expect(buttons.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("Estado de Loading", () => {
+    it("deve mostrar skeletons quando loading", () => {
+      render(<StepStyle {...defaultProps} isLoading={true} />);
+
+      // Não deve mostrar os estilos
+      expect(screen.queryByText("Minimalista Moderno")).not.toBeInTheDocument();
+    });
+
+    it("deve mostrar estilos após loading", () => {
+      render(<StepStyle {...defaultProps} isLoading={false} />);
+
+      const styles = screen.getAllByText("Minimalista Moderno");
+      expect(styles.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("Seleção de estilo", () => {
+    it("deve chamar onSelectStyle ao clicar em um estilo", () => {
+      render(<StepStyle {...defaultProps} />);
+
+      const styles = screen.getAllByText("Minimalista Moderno");
+      fireEvent.click(styles[0]);
+
+      expect(defaultProps.onSelectStyle).toHaveBeenCalledWith(1);
+    });
+
+    it("deve mostrar check no estilo selecionado", () => {
+      render(<StepStyle {...defaultProps} selectedStyleId={1} />);
+
+      const checks = screen.getAllByTestId("icon-check");
+      expect(checks.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("Navegação", () => {
+    it("deve chamar onBack ao clicar em Voltar", () => {
+      render(<StepStyle {...defaultProps} />);
+
+      const buttons = screen.getAllByText("Voltar");
+      fireEvent.click(buttons[0]);
+
+      expect(defaultProps.onBack).toHaveBeenCalledTimes(1);
+    });
+
+    it("deve chamar onGenerate ao clicar em Gerar Post", () => {
+      render(<StepStyle {...defaultProps} selectedStyleId={1} />);
+
+      const buttons = screen.getAllByText("Gerar Post");
+      fireEvent.click(buttons[0]);
+
+      expect(defaultProps.onGenerate).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("Validação", () => {
+    it("deve desabilitar botão Gerar sem estilo selecionado", () => {
+      render(<StepStyle {...defaultProps} selectedStyleId={null} />);
+
+      const buttons = screen.getAllByText("Gerar Post");
+      const button = buttons[0].closest("button");
+      expect(button).toBeDisabled();
+    });
+
+    it("deve habilitar botão Gerar com estilo selecionado", () => {
+      render(<StepStyle {...defaultProps} selectedStyleId={1} />);
+
+      const buttons = screen.getAllByText("Gerar Post");
+      const button = buttons[0].closest("button");
+      expect(button).not.toBeDisabled();
+    });
+  });
+
+  describe("Preview de imagem", () => {
+    it("deve mostrar imagem quando preview_image_url existe", () => {
+      const stylesWithImages: VisualStyle[] = [
+        {
+          id: 1,
+          name: "Com Imagem",
+          description: "Desc",
+          preview_image_url: "https://example.com/image.png",
+        },
+      ];
+
+      render(<StepStyle {...defaultProps} visualStyles={stylesWithImages} />);
+
+      const imgs = screen.getAllByAltText("Com Imagem");
+      expect(imgs[0]).toHaveAttribute("src", "https://example.com/image.png");
+    });
+
+    it("deve mostrar placeholder quando sem imagem", () => {
+      render(<StepStyle {...defaultProps} />);
+
+      // Deve mostrar a inicial do nome do estilo
+      const initials = screen.getAllByText("M"); // Minimalista
+      expect(initials.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/src/features/CreateFromOpportunity/components/__tests__/StepSuccess.test.tsx
+++ b/src/features/CreateFromOpportunity/components/__tests__/StepSuccess.test.tsx
@@ -12,6 +12,7 @@ vi.mock("react-router-dom", () => ({
 vi.mock("sonner", () => ({
   toast: {
     success: vi.fn(),
+    error: vi.fn(),
   },
 }));
 

--- a/src/features/CreateFromOpportunity/components/__tests__/StepSuccess.test.tsx
+++ b/src/features/CreateFromOpportunity/components/__tests__/StepSuccess.test.tsx
@@ -1,0 +1,137 @@
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { StepSuccess } from "../StepSuccess";
+
+// Mock react-router-dom
+const mockNavigate = vi.fn();
+vi.mock("react-router-dom", () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+// Mock sonner
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+  },
+}));
+
+// Mock lucide-react
+vi.mock("lucide-react", () => ({
+  CheckCircle2: () => <span data-testid="icon-check-circle">check</span>,
+  ExternalLink: () => <span data-testid="icon-external">external</span>,
+  Plus: () => <span data-testid="icon-plus">plus</span>,
+  Download: () => <span data-testid="icon-download">download</span>,
+  Copy: () => <span data-testid="icon-copy">copy</span>,
+}));
+
+describe("StepSuccess", () => {
+  const defaultProps = {
+    onCreateAnother: vi.fn(),
+    generatedContent: "Este é o conteúdo do post gerado #marketing #ia",
+    generatedImageUrl: "https://example.com/image.png",
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe("Renderização", () => {
+    it("deve renderizar ícone de sucesso", () => {
+      render(<StepSuccess {...defaultProps} />);
+
+      const icons = screen.getAllByTestId("icon-check-circle");
+      expect(icons.length).toBeGreaterThan(0);
+    });
+
+    it("deve renderizar mensagem de sucesso", () => {
+      render(<StepSuccess {...defaultProps} />);
+
+      const messages = screen.getAllByText("Post gerado com sucesso!");
+      expect(messages.length).toBeGreaterThan(0);
+    });
+
+    it("deve renderizar conteúdo gerado", () => {
+      render(<StepSuccess {...defaultProps} />);
+
+      const content = screen.getByText(/Este é o conteúdo do post gerado/);
+      expect(content).toBeInTheDocument();
+    });
+
+    it("deve renderizar imagem gerada", () => {
+      render(<StepSuccess {...defaultProps} />);
+
+      const image = screen.getByAltText("Post gerado");
+      expect(image).toBeInTheDocument();
+      expect(image).toHaveAttribute("src", defaultProps.generatedImageUrl);
+    });
+
+    it("deve renderizar botão Ver na Biblioteca", () => {
+      render(<StepSuccess {...defaultProps} />);
+
+      const buttons = screen.getAllByText("Ver na Biblioteca");
+      expect(buttons.length).toBeGreaterThan(0);
+    });
+
+    it("deve renderizar botão Criar Outro Post", () => {
+      render(<StepSuccess {...defaultProps} />);
+
+      const buttons = screen.getAllByText("Criar Outro Post");
+      expect(buttons.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("Navegação", () => {
+    it("deve navegar para /ideabank ao clicar em Ver na Biblioteca", () => {
+      render(<StepSuccess {...defaultProps} />);
+
+      const button = screen.getAllByRole("button").find(btn => btn.textContent?.includes("Ver na Biblioteca"));
+      expect(button).toBeDefined();
+      fireEvent.click(button!);
+
+      expect(mockNavigate).toHaveBeenCalledWith("/ideabank");
+    });
+
+    it("deve chamar onCreateAnother ao clicar em Criar Outro Post", () => {
+      render(<StepSuccess {...defaultProps} />);
+
+      const buttons = screen.getAllByText("Criar Outro Post");
+      fireEvent.click(buttons[0]);
+
+      expect(defaultProps.onCreateAnother).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("Ações de conteúdo", () => {
+    it("deve mostrar botão de copiar conteúdo", () => {
+      render(<StepSuccess {...defaultProps} />);
+
+      const copyButton = screen.getByText("Copiar");
+      expect(copyButton).toBeInTheDocument();
+    });
+
+    it("deve mostrar botão de baixar imagem", () => {
+      render(<StepSuccess {...defaultProps} />);
+
+      const downloadButton = screen.getByText("Baixar");
+      expect(downloadButton).toBeInTheDocument();
+    });
+
+    it("não deve renderizar imagem quando generatedImageUrl é null", () => {
+      render(<StepSuccess {...defaultProps} generatedImageUrl={null} />);
+
+      const image = screen.queryByAltText("Post gerado");
+      expect(image).not.toBeInTheDocument();
+    });
+
+    it("não deve renderizar conteúdo quando generatedContent é null", () => {
+      render(<StepSuccess {...defaultProps} generatedContent={null} />);
+
+      const copyButton = screen.queryByText("Copiar");
+      expect(copyButton).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/features/CreateFromOpportunity/components/__tests__/StepTopic.test.tsx
+++ b/src/features/CreateFromOpportunity/components/__tests__/StepTopic.test.tsx
@@ -1,0 +1,112 @@
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { StepTopic } from "../StepTopic";
+
+describe("StepTopic", () => {
+  const defaultProps = {
+    topic: "IA substituindo empregos",
+    category: "polemica" as const,
+    score: 95,
+    furtherDetails: "",
+    onFurtherDetailsChange: vi.fn(),
+    onNext: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  describe("Renderização", () => {
+    it("deve renderizar o tópico", () => {
+      render(<StepTopic {...defaultProps} />);
+      const topics = screen.getAllByText("IA substituindo empregos");
+      expect(topics.length).toBeGreaterThan(0);
+    });
+
+    it("deve renderizar o badge da categoria", () => {
+      render(<StepTopic {...defaultProps} />);
+      const badges = screen.getAllByText(/Polêmico/);
+      expect(badges.length).toBeGreaterThan(0);
+    });
+
+    it("deve renderizar o score", () => {
+      render(<StepTopic {...defaultProps} />);
+      const scores = screen.getAllByText("95/100");
+      expect(scores.length).toBeGreaterThan(0);
+    });
+
+    it("deve renderizar o textarea para detalhes", () => {
+      render(<StepTopic {...defaultProps} />);
+      const textareas = screen.getAllByPlaceholderText(/Foque em dados do mercado brasileiro/);
+      expect(textareas.length).toBeGreaterThan(0);
+    });
+
+    it("deve renderizar o botão Continuar", () => {
+      render(<StepTopic {...defaultProps} />);
+      const buttons = screen.getAllByText("Continuar");
+      expect(buttons.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("Interações", () => {
+    it("deve chamar onFurtherDetailsChange ao digitar", () => {
+      render(<StepTopic {...defaultProps} />);
+      const textareas = screen.getAllByPlaceholderText(
+        /Foque em dados do mercado brasileiro/
+      );
+      fireEvent.change(textareas[0], { target: { value: "Detalhes extras" } });
+      expect(defaultProps.onFurtherDetailsChange).toHaveBeenCalledWith(
+        "Detalhes extras"
+      );
+    });
+
+    it("deve chamar onNext ao clicar em Continuar", () => {
+      render(<StepTopic {...defaultProps} />);
+      const buttons = screen.getAllByText("Continuar");
+      fireEvent.click(buttons[0]);
+      expect(defaultProps.onNext).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("Categorias diferentes", () => {
+    it("deve mostrar badge correto para educativo", () => {
+      render(<StepTopic {...defaultProps} category="educativo" />);
+      const badges = screen.getAllByText(/Educativo/);
+      expect(badges.length).toBeGreaterThan(0);
+    });
+
+    it("deve mostrar badge correto para newsjacking", () => {
+      render(<StepTopic {...defaultProps} category="newsjacking" />);
+      const badges = screen.getAllByText(/Newsjacking/);
+      expect(badges.length).toBeGreaterThan(0);
+    });
+
+    it("deve mostrar badge correto para entretenimento", () => {
+      render(<StepTopic {...defaultProps} category="entretenimento" />);
+      const badges = screen.getAllByText(/Entretenimento/);
+      expect(badges.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("Valores pré-preenchidos", () => {
+    it("deve mostrar furtherDetails quando fornecido", () => {
+      render(
+        <StepTopic {...defaultProps} furtherDetails="Detalhes pré-existentes" />
+      );
+      const textareas = screen.getAllByPlaceholderText(
+        /Foque em dados do mercado brasileiro/
+      );
+      expect(textareas[0]).toHaveValue("Detalhes pré-existentes");
+    });
+
+    it("deve mostrar tópico vazio quando não fornecido", () => {
+      render(<StepTopic {...defaultProps} topic="" />);
+      const titles = screen.getAllByText("Tema da Oportunidade");
+      expect(titles.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/src/features/CreateFromOpportunity/components/index.ts
+++ b/src/features/CreateFromOpportunity/components/index.ts
@@ -1,0 +1,5 @@
+export { MobileStepIndicator } from "./MobileStepIndicator";
+export { StepTopic } from "./StepTopic";
+export { StepStyle } from "./StepStyle";
+export { StepGenerate } from "./StepGenerate";
+export { StepSuccess } from "./StepSuccess";

--- a/src/features/CreateFromOpportunity/hooks/__tests__/useUrlParams.test.ts
+++ b/src/features/CreateFromOpportunity/hooks/__tests__/useUrlParams.test.ts
@@ -116,5 +116,16 @@ describe("useUrlParams", () => {
 
       expect(result.current.topic).toBe("Tema com espaços");
     });
+
+    it("deve retornar 'outros' para category inválida", async () => {
+      vi.doMock("react-router-dom", () => ({
+        useSearchParams: () => [new URLSearchParams("category=invalida")],
+      }));
+
+      const { useUrlParams } = await import("../useUrlParams");
+      const { result } = renderHook(() => useUrlParams());
+
+      expect(result.current.category).toBe("outros");
+    });
   });
 });

--- a/src/features/CreateFromOpportunity/hooks/__tests__/useUrlParams.test.ts
+++ b/src/features/CreateFromOpportunity/hooks/__tests__/useUrlParams.test.ts
@@ -1,0 +1,120 @@
+import { renderHook, cleanup } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+describe("useUrlParams", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  describe("Extração de parâmetros", () => {
+    it("deve extrair topic da URL", async () => {
+      vi.doMock("react-router-dom", () => ({
+        useSearchParams: () => [new URLSearchParams("topic=IA substituindo empregos")],
+      }));
+
+      const { useUrlParams } = await import("../useUrlParams");
+      const { result } = renderHook(() => useUrlParams());
+
+      expect(result.current.topic).toBe("IA substituindo empregos");
+    });
+
+    it("deve extrair category da URL", async () => {
+      vi.doMock("react-router-dom", () => ({
+        useSearchParams: () => [new URLSearchParams("category=polemica")],
+      }));
+
+      const { useUrlParams } = await import("../useUrlParams");
+      const { result } = renderHook(() => useUrlParams());
+
+      expect(result.current.category).toBe("polemica");
+    });
+
+    it("deve extrair score da URL", async () => {
+      vi.doMock("react-router-dom", () => ({
+        useSearchParams: () => [new URLSearchParams("score=95")],
+      }));
+
+      const { useUrlParams } = await import("../useUrlParams");
+      const { result } = renderHook(() => useUrlParams());
+
+      expect(result.current.score).toBe(95);
+    });
+
+    it("deve extrair todos os parâmetros juntos", async () => {
+      vi.doMock("react-router-dom", () => ({
+        useSearchParams: () => [new URLSearchParams("topic=Tema teste&category=educativo&score=80")],
+      }));
+
+      const { useUrlParams } = await import("../useUrlParams");
+      const { result } = renderHook(() => useUrlParams());
+
+      expect(result.current.topic).toBe("Tema teste");
+      expect(result.current.category).toBe("educativo");
+      expect(result.current.score).toBe(80);
+    });
+  });
+
+  describe("Valores padrão", () => {
+    it("deve retornar string vazia para topic ausente", async () => {
+      vi.doMock("react-router-dom", () => ({
+        useSearchParams: () => [new URLSearchParams("")],
+      }));
+
+      const { useUrlParams } = await import("../useUrlParams");
+      const { result } = renderHook(() => useUrlParams());
+
+      expect(result.current.topic).toBe("");
+    });
+
+    it("deve retornar 'outros' para category ausente", async () => {
+      vi.doMock("react-router-dom", () => ({
+        useSearchParams: () => [new URLSearchParams("")],
+      }));
+
+      const { useUrlParams } = await import("../useUrlParams");
+      const { result } = renderHook(() => useUrlParams());
+
+      expect(result.current.category).toBe("outros");
+    });
+
+    it("deve retornar 0 para score ausente", async () => {
+      vi.doMock("react-router-dom", () => ({
+        useSearchParams: () => [new URLSearchParams("")],
+      }));
+
+      const { useUrlParams } = await import("../useUrlParams");
+      const { result } = renderHook(() => useUrlParams());
+
+      expect(result.current.score).toBe(0);
+    });
+  });
+
+  describe("Tratamento de valores inválidos", () => {
+    it("deve retornar 0 para score não numérico", async () => {
+      vi.doMock("react-router-dom", () => ({
+        useSearchParams: () => [new URLSearchParams("score=invalid")],
+      }));
+
+      const { useUrlParams } = await import("../useUrlParams");
+      const { result } = renderHook(() => useUrlParams());
+
+      expect(result.current.score).toBe(0);
+    });
+
+    it("deve decodificar URL encoded topic", async () => {
+      vi.doMock("react-router-dom", () => ({
+        useSearchParams: () => [new URLSearchParams("topic=Tema%20com%20espa%C3%A7os")],
+      }));
+
+      const { useUrlParams } = await import("../useUrlParams");
+      const { result } = renderHook(() => useUrlParams());
+
+      expect(result.current.topic).toBe("Tema com espaços");
+    });
+  });
+});

--- a/src/features/CreateFromOpportunity/hooks/index.ts
+++ b/src/features/CreateFromOpportunity/hooks/index.ts
@@ -1,0 +1,2 @@
+export { useCreateFromOpportunity } from "./useCreateFromOpportunity";
+export { useUrlParams } from "./useUrlParams";

--- a/src/features/CreateFromOpportunity/hooks/useCreateFromOpportunity.ts
+++ b/src/features/CreateFromOpportunity/hooks/useCreateFromOpportunity.ts
@@ -1,0 +1,230 @@
+import { useState, useCallback, useMemo } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { createFromOpportunityService } from "../services";
+import type { CreateFromOpportunityState, CreatePostData, Opportunity, VisualStyle } from "../types";
+import { useUrlParams } from "./useUrlParams";
+
+export const useCreateFromOpportunity = () => {
+  const queryClient = useQueryClient();
+  const urlParams = useUrlParams();
+
+  const [state, setState] = useState<CreateFromOpportunityState>({
+    step: 1,
+    topic: urlParams.topic,
+    category: urlParams.category,
+    score: urlParams.score,
+    furtherDetails: "",
+    selectedStyleId: null,
+    isGenerating: false,
+    generatedContent: null,
+    generatedImageUrl: null,
+    error: null,
+  });
+
+  // Fetch user opportunities for navigation
+  const {
+    data: opportunities = [],
+    isLoading: isLoadingOpportunities,
+  } = useQuery<Opportunity[]>({
+    queryKey: ["user-opportunities"],
+    queryFn: createFromOpportunityService.getOpportunities,
+    staleTime: 1000 * 60 * 5, // 5 minutes
+  });
+
+  // Find current opportunity index based on topic (partial match for URL compatibility)
+  const currentOpportunityIndex = useMemo(() => {
+    if (opportunities.length === 0) return -1;
+    // Try exact match first
+    const exactIndex = opportunities.findIndex((opp) => opp.topic === state.topic);
+    if (exactIndex !== -1) return exactIndex;
+    // Try partial match (topic from URL might be truncated)
+    return opportunities.findIndex((opp) =>
+      opp.topic.toLowerCase().includes(state.topic.toLowerCase()) ||
+      state.topic.toLowerCase().includes(opp.topic.toLowerCase())
+    );
+  }, [opportunities, state.topic]);
+
+  // Navigation info
+  const canNavigatePrev = currentOpportunityIndex > 0;
+  const canNavigateNext = currentOpportunityIndex < opportunities.length - 1 && currentOpportunityIndex !== -1;
+  // If topic not found in list, allow navigating to first opportunity
+  const canNavigateToFirst = currentOpportunityIndex === -1 && opportunities.length > 0;
+  const totalOpportunities = opportunities.length;
+
+  // Fetch visual styles
+  const {
+    data: visualStyles = [],
+    isLoading: isLoadingStyles,
+    error: stylesError,
+  } = useQuery<VisualStyle[]>({
+    queryKey: ["visual-styles"],
+    queryFn: createFromOpportunityService.getVisualStyles,
+    staleTime: 1000 * 60 * 10, // 10 minutes
+  });
+
+  // Generate post mutation
+  const generatePostMutation = useMutation({
+    mutationFn: createFromOpportunityService.generatePost,
+    onSuccess: (data) => {
+      toast.success("Post gerado com sucesso!");
+      // Invalidate posts query to refresh the list
+      queryClient.invalidateQueries({ queryKey: ["posts-with-ideas"] });
+      setState((prev) => ({
+        ...prev,
+        step: 4,
+        isGenerating: false,
+        generatedContent: data.post.content,
+        generatedImageUrl: data.post.image_url || null,
+      }));
+    },
+    onError: (error: Error) => {
+      toast.error("Erro ao gerar post. Tente novamente.");
+      setState((prev) => ({
+        ...prev,
+        isGenerating: false,
+        error: error.message,
+      }));
+    },
+  });
+
+  // Navigate to a specific opportunity
+  const goToOpportunity = useCallback((index: number) => {
+    if (index < 0 || index >= opportunities.length) return;
+
+    const opp = opportunities[index];
+    setState((prev) => ({
+      ...prev,
+      step: 1,
+      topic: opp.topic,
+      category: opp.category,
+      score: opp.score,
+      furtherDetails: "",
+      selectedStyleId: null,
+      generatedContent: null,
+      generatedImageUrl: null,
+      error: null,
+    }));
+  }, [opportunities]);
+
+  // Navigate to previous opportunity
+  const prevOpportunity = useCallback(() => {
+    if (canNavigatePrev) {
+      goToOpportunity(currentOpportunityIndex - 1);
+    }
+  }, [canNavigatePrev, currentOpportunityIndex, goToOpportunity]);
+
+  // Navigate to next opportunity
+  const nextOpportunity = useCallback(() => {
+    if (canNavigateNext) {
+      goToOpportunity(currentOpportunityIndex + 1);
+    }
+  }, [canNavigateNext, currentOpportunityIndex, goToOpportunity]);
+
+  // Navigation handlers
+  const nextStep = useCallback(() => {
+    setState((prev) => ({
+      ...prev,
+      step: Math.min(prev.step + 1, 4),
+    }));
+  }, []);
+
+  const prevStep = useCallback(() => {
+    setState((prev) => ({
+      ...prev,
+      step: Math.max(prev.step - 1, 1),
+    }));
+  }, []);
+
+  const goToStep = useCallback((step: number) => {
+    setState((prev) => ({
+      ...prev,
+      step: Math.max(1, Math.min(step, 4)),
+    }));
+  }, []);
+
+  // Update handlers
+  const setFurtherDetails = useCallback((details: string) => {
+    setState((prev) => ({
+      ...prev,
+      furtherDetails: details,
+    }));
+  }, []);
+
+  const setSelectedStyleId = useCallback((styleId: number | null) => {
+    setState((prev) => ({
+      ...prev,
+      selectedStyleId: styleId,
+    }));
+  }, []);
+
+  // Generate post handler
+  const generatePost = useCallback(() => {
+    if (!state.selectedStyleId) {
+      toast.error("Selecione um estilo visual");
+      return;
+    }
+
+    setState((prev) => ({
+      ...prev,
+      step: 3,
+      isGenerating: true,
+      error: null,
+    }));
+
+    const postData: CreatePostData = {
+      name: state.topic,
+      objective: "engagement",
+      type: "feed",
+      further_details: state.furtherDetails || "",
+      include_image: true,
+      style_id: state.selectedStyleId,
+    };
+
+    generatePostMutation.mutate(postData);
+  }, [state.topic, state.furtherDetails, state.selectedStyleId, generatePostMutation]);
+
+  // Create another post (reset state)
+  const createAnother = useCallback(() => {
+    setState({
+      step: 1,
+      topic: urlParams.topic,
+      category: urlParams.category,
+      score: urlParams.score,
+      furtherDetails: "",
+      selectedStyleId: null,
+      isGenerating: false,
+      generatedContent: null,
+      generatedImageUrl: null,
+      error: null,
+    });
+  }, [urlParams]);
+
+  return {
+    // State
+    ...state,
+    visualStyles,
+    isLoadingStyles,
+    stylesError,
+
+    // Opportunities navigation
+    opportunities,
+    isLoadingOpportunities,
+    currentOpportunityIndex,
+    totalOpportunities,
+    canNavigatePrev,
+    canNavigateNext: canNavigateNext || canNavigateToFirst,
+    prevOpportunity,
+    nextOpportunity: canNavigateToFirst ? () => goToOpportunity(0) : nextOpportunity,
+    goToOpportunity,
+
+    // Actions
+    nextStep,
+    prevStep,
+    goToStep,
+    setFurtherDetails,
+    setSelectedStyleId,
+    generatePost,
+    createAnother,
+  };
+};

--- a/src/features/CreateFromOpportunity/hooks/useUrlParams.ts
+++ b/src/features/CreateFromOpportunity/hooks/useUrlParams.ts
@@ -2,17 +2,25 @@ import { useSearchParams } from "react-router-dom";
 import { useMemo } from "react";
 import type { OpportunityParams, CategoryKey } from "../types";
 
+const VALID_CATEGORIES: CategoryKey[] = [
+  "polemica", "educativo", "newsjacking",
+  "entretenimento", "estudo_caso", "futuro", "outros",
+];
+
 export const useUrlParams = (): OpportunityParams => {
   const [searchParams] = useSearchParams();
 
   return useMemo(() => {
     const topic = searchParams.get("topic") || "";
-    const category = (searchParams.get("category") || "outros") as CategoryKey;
+    const rawCategory = searchParams.get("category") || "outros";
+    const category: CategoryKey = VALID_CATEGORIES.includes(rawCategory as CategoryKey)
+      ? (rawCategory as CategoryKey)
+      : "outros";
     const scoreStr = searchParams.get("score") || "0";
     const score = parseInt(scoreStr, 10) || 0;
 
     return {
-      topic: decodeURIComponent(topic),
+      topic,
       category,
       score,
     };

--- a/src/features/CreateFromOpportunity/hooks/useUrlParams.ts
+++ b/src/features/CreateFromOpportunity/hooks/useUrlParams.ts
@@ -1,0 +1,20 @@
+import { useSearchParams } from "react-router-dom";
+import { useMemo } from "react";
+import type { OpportunityParams, CategoryKey } from "../types";
+
+export const useUrlParams = (): OpportunityParams => {
+  const [searchParams] = useSearchParams();
+
+  return useMemo(() => {
+    const topic = searchParams.get("topic") || "";
+    const category = (searchParams.get("category") || "outros") as CategoryKey;
+    const scoreStr = searchParams.get("score") || "0";
+    const score = parseInt(scoreStr, 10) || 0;
+
+    return {
+      topic: decodeURIComponent(topic),
+      category,
+      score,
+    };
+  }, [searchParams]);
+};

--- a/src/features/CreateFromOpportunity/index.tsx
+++ b/src/features/CreateFromOpportunity/index.tsx
@@ -9,7 +9,6 @@ import {
   StepSuccess,
 } from "./components";
 import { useCreateFromOpportunity } from "./hooks";
-import type { CategoryKey } from "./types";
 
 export const CreateFromOpportunity = () => {
   const navigate = useNavigate();
@@ -100,7 +99,7 @@ export const CreateFromOpportunity = () => {
         {step === 1 && (
           <StepTopic
             topic={topic}
-            category={category as CategoryKey}
+            category={category}
             score={score}
             furtherDetails={furtherDetails}
             onFurtherDetailsChange={setFurtherDetails}

--- a/src/features/CreateFromOpportunity/index.tsx
+++ b/src/features/CreateFromOpportunity/index.tsx
@@ -1,0 +1,145 @@
+import { ArrowLeft } from "lucide-react";
+import { useNavigate } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+import {
+  MobileStepIndicator,
+  StepTopic,
+  StepStyle,
+  StepGenerate,
+  StepSuccess,
+} from "./components";
+import { useCreateFromOpportunity } from "./hooks";
+import type { CategoryKey } from "./types";
+
+export const CreateFromOpportunity = () => {
+  const navigate = useNavigate();
+  const {
+    step,
+    topic,
+    category,
+    score,
+    furtherDetails,
+    selectedStyleId,
+    visualStyles,
+    isLoadingStyles,
+    isGenerating,
+    generatedContent,
+    generatedImageUrl,
+    // Opportunities navigation
+    currentOpportunityIndex,
+    totalOpportunities,
+    canNavigatePrev,
+    canNavigateNext,
+    prevOpportunity,
+    nextOpportunity,
+    // Actions
+    nextStep,
+    prevStep,
+    setFurtherDetails,
+    setSelectedStyleId,
+    generatePost,
+    createAnother,
+  } = useCreateFromOpportunity();
+
+  const selectedStyle = visualStyles.find((s) => s.id === selectedStyleId);
+
+  const handleBack = () => {
+    if (step === 1) {
+      navigate(-1);
+    } else {
+      prevStep();
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-background">
+      {/* Header */}
+      <header className="sticky top-0 z-50 bg-background border-b">
+        <div className="flex items-center justify-between px-4 h-14">
+          {/* Back Button - only show on steps 1-2 */}
+          {step <= 2 ? (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={handleBack}
+              className="gap-2"
+            >
+              <ArrowLeft className="w-4 h-4" />
+              <span className="hidden sm:inline">Voltar</span>
+            </Button>
+          ) : (
+            <div className="w-20" />
+          )}
+
+          {/* Logo */}
+          <div className="flex items-center">
+            <img
+              src="https://postnow-image-bucket-prod.s3.sa-east-1.amazonaws.com/postnow_logo.png"
+              alt="PostNow"
+              className="h-6 dark:hidden"
+            />
+            <img
+              src="https://postnow-image-bucket-prod.s3.sa-east-1.amazonaws.com/postnow_logo_white.png"
+              alt="PostNow"
+              className="h-6 hidden dark:block"
+            />
+          </div>
+
+          {/* Spacer for centering */}
+          <div className="w-20" />
+        </div>
+      </header>
+
+      {/* Step Indicator */}
+      {step < 4 && (
+        <MobileStepIndicator currentStep={step} totalSteps={3} />
+      )}
+
+      {/* Main Content */}
+      <main className="max-w-lg mx-auto">
+        {step === 1 && (
+          <StepTopic
+            topic={topic}
+            category={category as CategoryKey}
+            score={score}
+            furtherDetails={furtherDetails}
+            onFurtherDetailsChange={setFurtherDetails}
+            onNext={nextStep}
+            currentIndex={currentOpportunityIndex}
+            totalOpportunities={totalOpportunities}
+            canNavigatePrev={canNavigatePrev}
+            canNavigateNext={canNavigateNext}
+            onPrevOpportunity={prevOpportunity}
+            onNextOpportunity={nextOpportunity}
+          />
+        )}
+
+        {step === 2 && (
+          <StepStyle
+            visualStyles={visualStyles}
+            isLoading={isLoadingStyles}
+            selectedStyleId={selectedStyleId}
+            onSelectStyle={setSelectedStyleId}
+            onBack={prevStep}
+            onGenerate={generatePost}
+          />
+        )}
+
+        {step === 3 && (
+          <StepGenerate
+            isGenerating={isGenerating}
+            selectedStyle={selectedStyle}
+          />
+        )}
+
+        {step === 4 && (
+          <StepSuccess
+            onCreateAnother={createAnother}
+            generatedContent={generatedContent}
+            generatedImageUrl={generatedImageUrl}
+          />
+        )}
+      </main>
+    </div>
+  );
+};

--- a/src/features/CreateFromOpportunity/services/index.ts
+++ b/src/features/CreateFromOpportunity/services/index.ts
@@ -1,0 +1,39 @@
+import { api } from "@/lib/api";
+import type { CreatePostData, GeneratedPost, Opportunity, VisualStyle } from "../types";
+
+interface GeneratePostResponse {
+  message: string;
+  post: GeneratedPost;
+}
+
+interface OpportunitiesResponse {
+  opportunities: Opportunity[];
+  total: number;
+}
+
+export const createFromOpportunityService = {
+  // Fetch all visual styles
+  async getVisualStyles(): Promise<VisualStyle[]> {
+    const response = await api.get<VisualStyle[]>(
+      "api/v1/creator-profile/visual-style-preferences/"
+    );
+    return response.data;
+  },
+
+  // Fetch user opportunities
+  async getOpportunities(): Promise<Opportunity[]> {
+    const response = await api.get<OpportunitiesResponse>(
+      "api/v1/client-context/opportunities/"
+    );
+    return response.data.opportunities;
+  },
+
+  // Generate post with specific style
+  async generatePost(data: CreatePostData): Promise<GeneratePostResponse> {
+    const response = await api.post<GeneratePostResponse>(
+      "api/v1/ideabank/generate/post-idea/",
+      data
+    );
+    return response.data;
+  },
+};

--- a/src/features/CreateFromOpportunity/types/index.ts
+++ b/src/features/CreateFromOpportunity/types/index.ts
@@ -1,0 +1,69 @@
+export interface VisualStyle {
+  id: number;
+  name: string;
+  description: string;
+  preview_image_url?: string;
+}
+
+export interface OpportunityParams {
+  topic: string;
+  category: string;
+  score: number;
+}
+
+export interface CreatePostData {
+  name: string;
+  objective: "branding" | "engagement" | "education" | "sales" | "awareness" | "lead_generation";
+  type: "feed" | "reels" | "story" | "carousel";
+  further_details?: string;
+  include_image: boolean;
+  style_id?: number;
+}
+
+export interface GeneratedPost {
+  id: number;
+  content: string;
+  image_url?: string;
+}
+
+export interface Opportunity {
+  topic: string;
+  description: string;
+  score: number;
+  category: CategoryKey;
+  category_title: string;
+  url_fonte?: string;
+  enriched_analysis?: string;
+}
+
+export interface CreateFromOpportunityState {
+  step: number;
+  topic: string;
+  category: string;
+  score: number;
+  furtherDetails: string;
+  selectedStyleId: number | null;
+  isGenerating: boolean;
+  generatedContent: string | null;
+  generatedImageUrl: string | null;
+  error: string | null;
+}
+
+export type CategoryKey =
+  | "polemica"
+  | "educativo"
+  | "newsjacking"
+  | "entretenimento"
+  | "estudo_caso"
+  | "futuro"
+  | "outros";
+
+export const CATEGORY_LABELS: Record<CategoryKey, { label: string; emoji: string }> = {
+  polemica: { label: "Polêmico", emoji: "🔥" },
+  educativo: { label: "Educativo", emoji: "🧠" },
+  newsjacking: { label: "Newsjacking", emoji: "📰" },
+  entretenimento: { label: "Entretenimento", emoji: "😂" },
+  estudo_caso: { label: "Estudo de Caso", emoji: "💼" },
+  futuro: { label: "Futuro", emoji: "🔮" },
+  outros: { label: "Outros", emoji: "⚡" },
+};

--- a/src/features/CreateFromOpportunity/types/index.ts
+++ b/src/features/CreateFromOpportunity/types/index.ts
@@ -7,7 +7,7 @@ export interface VisualStyle {
 
 export interface OpportunityParams {
   topic: string;
-  category: string;
+  category: CategoryKey;
   score: number;
 }
 
@@ -39,7 +39,7 @@ export interface Opportunity {
 export interface CreateFromOpportunityState {
   step: number;
   topic: string;
-  category: string;
+  category: CategoryKey;
   score: number;
   furtherDetails: string;
   selectedStyleId: number | null;

--- a/src/pages/CreateFromOpportunityPage.tsx
+++ b/src/pages/CreateFromOpportunityPage.tsx
@@ -1,0 +1,5 @@
+import { CreateFromOpportunity } from "@/features/CreateFromOpportunity";
+
+export const CreateFromOpportunityPage = () => {
+  return <CreateFromOpportunity />;
+};


### PR DESCRIPTION
## Tipo de mudança
- [x] `feat`: Nova funcionalidade

## Descrição

Página `/create` que permite criar posts a partir de links enviados por email com oportunidades de conteúdo.

### Dois modos de uso

**1. Via Email (automático):**
Quando `from=email` está nos query params, o post é gerado automaticamente sem interação do usuário. A tela mostra progress bar animada com mensagens de status até o resultado aparecer.

**2. Via navegação manual (wizard):**
Wizard de 4 passos:
1. **Tópico** — Revisa o tópico, adiciona detalhes, navega entre oportunidades
2. **Estilo** — Escolhe o estilo visual da imagem
3. **Gerar** — Gera o post com IA (progress bar + mensagens)
4. **Sucesso** — Mostra resultado com opções de copiar/baixar

### Features técnicas
- Leitura de parâmetros da URL (`topic`, `category`, `score`, `from`)
- Validação de category contra valores permitidos (fallback para "outros")
- Navegação entre oportunidades do usuário (prev/next)
- Integração com API de geração de posts
- Mobile-first design
- Step indicator responsivo (hidden no modo email)

### Revisão de qualidade (commit a838828)

| Correção | Arquivo |
|----------|---------|
| Clipboard com try/catch (pode falhar sem HTTPS) | `StepSuccess.tsx` |
| Download real com `<a download>` em vez de `window.open` | `StepSuccess.tsx` |
| Removido `decodeURIComponent` duplicado (URLSearchParams já decodifica) | `useUrlParams.ts` |
| Validação de category contra lista de valores válidos | `useUrlParams.ts` |
| `category` tipada como `CategoryKey` em vez de `string` | `types/index.ts` |
| Removida prop `businessName` não utilizada | `StepGenerate.tsx` |

## Como foi testado?

- [x] `npm run lint` passa (0 erros, 60 warnings pré-existentes)
- [x] `npm run build` compila
- [x] Testes passam (`npm run test`) — **260 testes** (todos passando)
- [x] Testado end-to-end via email real (modo automático)
- [x] Testado manualmente no navegador (modo wizard)

## Qualidade do Código

- [x] Não usei `@ts-nocheck` ou `@ts-ignore`
- [x] Não usei `any` sem necessidade
- [x] Não desabilitei regras de lint em massa
- [x] A solução resolve o problema (não apenas esconde)

## Checklist

- [x] Meu código segue o padrão de estilo do projeto
- [x] Realizei self-review do meu código
- [x] Testei em diferentes tamanhos de tela
- [x] Li o CLAUDE.md e segui as diretrizes

## Dependências

- **Backend**: PR #42 no PostNow-REST-API (endpoints de geração + oportunidades)
- **Frontend**: PR #37 adiciona autenticação via magic link

## Issues relacionadas

Substitui PR #31 (que foi fechada por conflitos)